### PR TITLE
Fix logger context override bug

### DIFF
--- a/src/modules/Logging/services/LoggerService.ts
+++ b/src/modules/Logging/services/LoggerService.ts
@@ -3,22 +3,26 @@ import { ConsoleLoggerService } from "./ConsoleLoggerService";
 import { ILogger } from "../interfaces/ILogger";
 
 export class LoggerService implements ILogger {
-  private static instance: LoggerService;
+  /**
+   * Separate logger instances are kept per context to avoid
+   * accidentally overriding the context value when multiple modules
+   * request a logger. Each context returns the same instance on
+   * subsequent calls.
+   */
+  private static instances: Map<string, LoggerService> = new Map();
   private loggers: ILogger[] = [];
-  private context: string = '';
+  private context: string;
 
-  private constructor() {
+  private constructor(context = '') {
+    this.context = context;
     this.loggers.push(new ConsoleLoggerService());
   }
 
-  static getInstance(context?: string): LoggerService {
-    if (!LoggerService.instance) {
-      LoggerService.instance = new LoggerService();
+  static getInstance(context = ''): LoggerService {
+    if (!LoggerService.instances.has(context)) {
+      LoggerService.instances.set(context, new LoggerService(context));
     }
-    if (context) {
-      LoggerService.instance.setContext(context);
-    }
-    return LoggerService.instance;
+    return LoggerService.instances.get(context)!;
   }
 
   setContext(context: string): void {


### PR DESCRIPTION
## Summary
- fix logger context override by storing separate instances per context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849d8785cd48325916451c6a5721d70