### PR TITLE
Add Vitest setup and basic utils test

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ npm i
 npm run dev
 ```
 
+## Running tests
+
+```sh
+npm test
+```
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:watch": "vitest --watch"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -87,6 +89,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from './utils';
+
+describe('cn', () => {
+  it('merges multiple class names', () => {
+    expect(cn('a', 'b')).toBe('a b');
+  });
+
+  it('ignores falsy values', () => {
+    expect(cn('a', { b: false, c: true })).toBe('a c');
+  });
+
+  it('handles tailwind overrides', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- set up Vitest for running tests
- write initial tests for `cn` utility
- document how to run tests in the README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849da72e10c83259710557d445b3de2