### PR TITLE
Fix success flag when closing expired statements fails

### DIFF
--- a/supabase/functions/statement-process/index.ts
+++ b/supabase/functions/statement-process/index.ts
@@ -60,9 +60,9 @@ serve(async (req) => {
       if (expiredError) {
         console.error(`statement-process: Error closing expired statements: ${expiredError.message}`);
         return new Response(
-          JSON.stringify({ 
-            success: true, 
-            message: 'Future statements updated but error closing expired statements', 
+          JSON.stringify({
+            success: false,
+            message: 'Future statements updated, but failed to close expired statements',
             future: futureResult,
             expired: { error: expiredError.message }
           }),


### PR DESCRIPTION
## Summary
- mark failure when closing expired statements in `statement-process`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dc4b823c8325ad8279c47a7b33e8